### PR TITLE
Issues/21 load session on refresh

### DIFF
--- a/src/components/StatusBar.jsx
+++ b/src/components/StatusBar.jsx
@@ -2,9 +2,10 @@ import '../styles/StatusBar.css';
 
 export default function StatusBar(props) {
   const { currentSession, projects} = props;
-
+  console.log(projects, currentSession)
   const tracking = currentSession.id !== undefined;
-  const projectTitle = tracking && projects[currentSession.project_id].title
+  const projectsLoaded = projects[currentSession.project_id] !== undefined;
+  const projectTitle = tracking && projectsLoaded && projects[currentSession.project_id].title
 
   return (
     <div className={`statusBar mb-2 border-top border-info

--- a/src/components/StatusBar.jsx
+++ b/src/components/StatusBar.jsx
@@ -2,7 +2,6 @@ import '../styles/StatusBar.css';
 
 export default function StatusBar(props) {
   const { currentSession, projects} = props;
-  console.log(projects, currentSession)
   const tracking = currentSession.id !== undefined;
   const projectsLoaded = projects[currentSession.project_id] !== undefined;
   const projectTitle = tracking && projectsLoaded && projects[currentSession.project_id].title

--- a/src/hooks/useSessionTracking.js
+++ b/src/hooks/useSessionTracking.js
@@ -7,6 +7,10 @@ export default function useSessionTracking(username) {
   useEffect(() => {
     // When the username changes, ping the server to see if there's an open session.
     // If there is, load it into the state.
+    axios.get(`/api/sessions/current`)
+         .then(res => {
+           if(res.data[0]) setCurrentSession(res.data[0]);
+         })
   }, [username])
 
   const toggleSession = event => {


### PR DESCRIPTION
The useSessionTracking hook now detects the most recent open session for a user and loads it into state when the username changes.