### PR TITLE
Issues/59 block styling

### DIFF
--- a/src/components/Block.jsx
+++ b/src/components/Block.jsx
@@ -12,27 +12,29 @@ export default function Block(props) {
   const spacer = project_id === -1;
 
   const lengthStr = spacer ? "1rem" : `${length}rem`
-  const projectFontSize = length > 1 ? "1rem" : ".6rem"
-  const intervalFontSize = length > 1 ? ".8rem" : ".6rem"
 
   const blockClass = classNames("block", "list-group-item", {
     spacer,
-    "hour-line": spacer && !getHM(end_time)[1], // if we're a spacer and end-time minutes are 0
+    project: !spacer,
     short: length === 1,
+    "hour-end": spacer &&
+                getHM(end_time)[1] === 0, // if we're a spacer and end-time minutes are 0
+    "hour-start": spacer &&
+                getHM(start_time)[1] === 0,
   });
 
   return(
     <li
       id={id}
       className={blockClass}
-      style={{height: lengthStr, fontSize: projectFontSize}}
+      style={{height: lengthStr}}
       projectid={project_id}
     >
         {!spacer &&
-        <>
+        <div className={"block-body"}>
           <p>{title}</p>
-          <span className="text-muted" style={{ fontSize: intervalFontSize}}>{interval}</span>
-        </>
+          <span className="text-muted">{interval}</span>
+        </div>
         }
     </li>
   )

--- a/src/components/Block.jsx
+++ b/src/components/Block.jsx
@@ -1,28 +1,39 @@
 import '../styles/Block.css'
-import { makeTimeString, makeShortIntervalString } from '../helpers/stringHelpers'
+import classNames from 'classnames'
+import { makeShortIntervalString } from '../helpers/stringHelpers'
+import { getHM } from '../helpers/timeHelpers'
 
 export default function Block(props) {
-  const { title, project_id, length, start_time, end_time } = props;
+  const { id, title, project_id, length, start_time, end_time } = props;
 
   const interval = makeShortIntervalString(start_time, end_time);
 
   // Is this block a placeholder?
-  const placeholder = project_id === -1;
+  const spacer = project_id === -1;
 
-  const blockClass = placeholder ? "block_placeholder" : "block"
-  const backgroundClass = placeholder ? "block_placeholder_background" : "block_background"
-  const lengthStr = placeholder ? "1rem" : `${length}rem`
+  const lengthStr = spacer ? "1rem" : `${length}rem`
+  const projectFontSize = length > 1 ? "1rem" : ".6rem"
+  const intervalFontSize = length > 1 ? ".8rem" : ".6rem"
+
+  const blockClass = classNames("block", "list-group-item", {
+    spacer,
+    "hour-line": spacer && !getHM(end_time)[1], // if we're a spacer and end-time minutes are 0
+    short: length === 1,
+  });
+
   return(
-    <li className={"list-group-item " + backgroundClass}
-      style={{height: lengthStr}}
+    <li
+      id={id}
+      className={blockClass}
+      style={{height: lengthStr, fontSize: projectFontSize}}
+      projectid={project_id}
     >
-      <div
-        className={blockClass}
-        projectid={project_id}
-      >
-        {!placeholder && <h5>{title}</h5>}
-        {interval}
-      </div>
+        {!spacer &&
+        <>
+          <p>{title}</p>
+          <span className="text-muted" style={{ fontSize: intervalFontSize}}>{interval}</span>
+        </>
+        }
     </li>
   )
 }

--- a/src/components/Block.jsx
+++ b/src/components/Block.jsx
@@ -1,11 +1,10 @@
 import '../styles/Block.css'
-import { makeTimeString, shortenHHMM } from '../helpers/stringHelpers'
+import { makeTimeString, makeShortIntervalString } from '../helpers/stringHelpers'
 
 export default function Block(props) {
   const { title, project_id, length, start_time, end_time } = props;
 
-  const startTimeStr = shortenHHMM(makeTimeString(start_time))
-  const endTimeStr = makeTimeString(end_time)
+  const interval = makeShortIntervalString(start_time, end_time);
 
   // Is this block a placeholder?
   const placeholder = project_id === -1;
@@ -22,7 +21,7 @@ export default function Block(props) {
         projectid={project_id}
       >
         {!placeholder && <h5>{title}</h5>}
-        {startTimeStr} to {endTimeStr}
+        {interval}
       </div>
     </li>
   )

--- a/src/components/Block.jsx
+++ b/src/components/Block.jsx
@@ -1,10 +1,10 @@
 import '../styles/Block.css'
-import { makeTimeString } from '../helpers/stringHelpers'
+import { makeTimeString, shortenHHMM } from '../helpers/stringHelpers'
 
 export default function Block(props) {
   const { title, project_id, length, start_time, end_time } = props;
 
-  const startTimeStr = makeTimeString(start_time)
+  const startTimeStr = shortenHHMM(makeTimeString(start_time))
   const endTimeStr = makeTimeString(end_time)
 
   // Is this block a placeholder?

--- a/src/helpers/stringHelpers.js
+++ b/src/helpers/stringHelpers.js
@@ -13,6 +13,11 @@ export function makeTimeString(time) {
   return new Date(time).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit'})
 }
 
+export function shortenHHMM(time) {
+  console.log(time.split(':')[1]);
+  return time.split(':')[1] === "00" ? time.split(':')[0] : time;
+}
+
 // Give time in HH:MM without AM or PM.
 export function makeHHMMTimeString(time) {
   return new Date(time).toLocaleTimeString([], 

--- a/src/helpers/stringHelpers.js
+++ b/src/helpers/stringHelpers.js
@@ -1,21 +1,16 @@
-import { getLastSunday, getNextSaturday } from './timeHelpers'
+import { getLastSunday, getNextSaturday, getHM } from './timeHelpers'
 
 // Gives time in H:MM AM/PM format, for humans to read.
 export function makeTimeString(time) {
   if (time.length === 5) {
     const timeArr = time.split(":");
-    let amPm = timeArr[0] >= 12 ? "PM" : "AM"
+    let amPm = timeArr[0] >= 12 ? "pm" : "am"
 
     // -12 hours if we're at 13:00 or onward
     timeArr[0] -= timeArr[0] > 12 ? 12 : 0;
     return `${timeArr.join(":")} ${amPm}`
   }
   return new Date(time).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit'})
-}
-
-export function shortenHHMM(time) {
-  console.log(time.split(':')[1]);
-  return time.split(':')[1] === "00" ? time.split(':')[0] : time;
 }
 
 // Give time in HH:MM without AM or PM.
@@ -84,4 +79,29 @@ export function makeDurationFromHHMM(start, end) {
   const hours = h ? `${h}h ` : '';
   const mins = `${m}m`
   return hours + mins
+}
+
+// Takes in a 24h hour and returns AM or PM.
+export function AMorPM(hour) {
+  return hour < 12 ? "am" : "pm"
+}
+
+/* Return an array containing the two AM/PM strings to add to
+  the start and end of a time interval.
+*/
+export function intervalAMPM(hour1, hour2) {
+  if (AMorPM(hour1) === AMorPM(hour2)) {
+    return ["", AMorPM(hour1)];
+  }
+  return ["am", "pm"]
+}
+
+export function makeShortIntervalString(start, end) {
+  const [startH, startM] = getHM(start);
+  const [endH, endM] = getHM(end);
+  const [AMPM1, AMPM2] = intervalAMPM(startH, endH);
+
+  const startStr = `${startH}${startM ? ":" + startM : ""} ${AMPM1}`
+  const endStr = `${endH}${endM ? ":" + endM : ""} ${AMPM2}`
+  return `${startStr} – ${endStr}`
 }

--- a/src/helpers/timeHelpers.js
+++ b/src/helpers/timeHelpers.js
@@ -30,6 +30,11 @@ export function getTimeIntervalUnits(start, end) {
   return [h, m, s]
 }
 
+export function getHM(time) {
+  const obj = new Date(time);
+  return [obj.getHours(), obj.getMinutes()];
+}
+
 // Set h/min/s/ms of a given date to 0.
 export function makeZeroDate(date) {
   date.setHours(0);

--- a/src/styles/Block.css
+++ b/src/styles/Block.css
@@ -1,23 +1,40 @@
+@import './global.css';
+
 .block {
   background-color: rgb(187, 187, 255);
   height: 100%;
   border: 1px solid rgba(0,0,0,.125);
   border-width: 0px 0px 1px;
   border-radius: .3rem;
+  display: flex;
+  gap: .5rem;
+  padding-left: 0.5rem;
 }
 
-.block_placeholder {
-  font-size: .75rem;
-  padding: 0rem;
-  background-color: transparent;
-  color: transparent;
-  height: 100%;
+.block:last-child {
+  margin-bottom: 2rem;
+  border: 0;
 }
 
-.block_placeholder:hover {
-  font-size: .75rem;
-  padding: 0rem;
-  background-color: transparent;
-  color: black;
-  border: 1px black dashed;
+.block p {
+  margin: 0;
+}
+
+.block span {
+  font-size: 0.8rem;
+  margin: 0;
+}
+
+.block.spacer {
+  background-color: white;
+  border-radius: 0;
+  border-width: 0;
+}
+
+.block.spacer.hour-line {
+  border-width: 0 0 1px;
+}
+
+.block.spacer:hover {
+  box-shadow: var(--focus-shadow-inner);
 }

--- a/src/styles/Block.css
+++ b/src/styles/Block.css
@@ -7,8 +7,9 @@
   border-width: 0px 0px 1px;
   border-radius: .3rem;
   display: flex;
-  gap: .5rem;
-  padding-left: 0.5rem;
+  align-items: flex-start;
+  padding: 0 0 0 0.5rem;
+  margin-right: .5rem;
 }
 
 .block:last-child {
@@ -16,23 +17,58 @@
   border: 0;
 }
 
-.block p {
+.block.project:hover {
+  cursor:pointer;
+  box-shadow: var(--focus-shadow-inner)
+}
+
+/* Body style for shortest (15-minute) blocks */
+
+.block.short .block-body {
+  align-items: flex-start;
+  font-size: .7rem;
+}
+
+.block.short span {
+  font-size: .7rem;
+}
+
+/************************************/
+
+/* Body style for all other blocks */
+
+.block-body {
+  display: flex;
+  align-items: flex-end;
+  gap: .5rem;
+}
+
+.block-body p {
   margin: 0;
 }
 
-.block span {
+.block-body span {
   font-size: 0.8rem;
   margin: 0;
 }
+
+/************************************/
+
+/* Spacer styles */
 
 .block.spacer {
   background-color: white;
   border-radius: 0;
   border-width: 0;
+  margin-right: 0;
 }
 
-.block.spacer.hour-line {
+.block.spacer.hour-end {
   border-width: 0 0 1px;
+}
+
+.block.project + .hour-start {
+  border-width: 1px 0 0 0;
 }
 
 .block.spacer:hover {

--- a/src/styles/BlockList.css
+++ b/src/styles/BlockList.css
@@ -2,13 +2,5 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-}
-
-.blockList > .list-group-item {
-  padding: 0;
-}
-
-.blockList > .block_background {
-  border-width: 0px;
-  padding-bottom: .1rem;
+  background-color: white;
 }

--- a/src/styles/DaySchedule.css
+++ b/src/styles/DaySchedule.css
@@ -3,6 +3,7 @@
   flex-direction: column;
   align-items: center;
   width: 66%;
+  margin-bottom: -15px;
 }
 
 .dayScheduleHeader {

--- a/src/styles/SessionItem.css
+++ b/src/styles/SessionItem.css
@@ -18,10 +18,6 @@
   outline: none;
 }
 
-.session-item:last-child {
-  margin-bottom: 2rem;
-}
-
 .session-item form {
   display: flex;
   flex-flow: row wrap;

--- a/src/styles/SessionList.css
+++ b/src/styles/SessionList.css
@@ -3,8 +3,9 @@
 .session-list {
   width: 100%;
   transition: all .3s;
-  margin-bottom: -15px;
+  margin-bottom: .5rem;
 }
 
-.session-list:focus-within {
+.session-list:last-child {
+  margin-bottom: 2rem; /* Ensure enough room at bottom of scroll area */
 }

--- a/src/styles/SessionsPage.css
+++ b/src/styles/SessionsPage.css
@@ -4,6 +4,7 @@
   flex-direction: column;
   overflow: scroll;
   scroll-behavior: smooth;
+  margin-bottom: -15px; /* Covers up the horizontal scrollbar. */
 }
 
 .sessions header {


### PR DESCRIPTION
Block styling is a bit more visually pleasing now. Updated the block duration string to be a bit shorter: only using AM or PM once if possible, and only showing the hour if the minutes are 0. Added hover outline and smaller fonts for 15-minute blocks. Updated spacer styles to only have borders at each hour, and to show a better indicator on hover. Removed text for spacer blocks. 

Closes #59.